### PR TITLE
⚡ Bolt: Optimize SPN generation by removing loop overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-05-24 - Using `sum` over `all` for matrix checks
 **Learning:** Octave's `sum(matrix, dim) == target` can be slightly faster than `all(matrix == target, dim)` in some tight loop scenarios where the matrix is large.
 **Action:** Consider `sum(...) == target` as a micro-optimization alternative to `all(...)` when profiling reveals a bottleneck in logical reductions.
+
+## 2024-04-11 - Loop Overhead with Octave RNG functions
+**Learning:** Calling `randi` or `rand` repeatedly inside a `for` loop incurs massive function call overhead in Octave, particularly heavily impacting algorithms that iteratively build graphs element-by-element (like the initial connected graph step in `spn_generate_random.m`).
+**Action:** When a loop requires random numbers for each iteration, pre-allocate and pre-compute the random values in vectorized arrays before the loop (e.g., `rand_choices = randi(max_val, num_iterations, 1)`). Inside the loop, read from these pre-computed arrays (and use `mod(val, current_max)+1` to handle dynamic ranges if needed) instead of calling the RNG functions.

--- a/spn_generate_random.m
+++ b/spn_generate_random.m
@@ -92,17 +92,24 @@ function [cm, lambda] = spn_generate_random(pn, tn, prob, max_lambda)
   % 2. Iteratively add the remaining nodes to the subgraph.
   % We shuffle the remaining nodes to add them in a random order.
   shuffled_nodes = remaining_nodes(randperm(numel(remaining_nodes)));
+  num_nodes = length(shuffled_nodes);
 
-  for node = shuffled_nodes'
+  % Pre-calculate random choices to avoid randi() and rand() overhead inside the loop
+  rand_choices_t = randi(intmax('int32'), num_nodes, 1);
+  rand_choices_p = randi(intmax('int32'), num_nodes, 1);
+  rand_dir = rand(num_nodes, 1) > 0.5;
+
+  for k = 1:num_nodes
+    node = shuffled_nodes(k);
     if node <= pn % The current node to add is a place.
       % Connect this new place to a random transition already in the subgraph.
       new_place = node;
-      connected_transition = transitions_in_subgraph(randi(transitions_count));
+      connected_transition = transitions_in_subgraph(mod(rand_choices_t(k), transitions_count) + 1);
       places_count++;
       places_in_subgraph(places_count) = node;
     else % The current node to add is a transition.
       % Connect this new transition to a random place already in the subgraph.
-      new_place = places_in_subgraph(randi(places_count));
+      new_place = places_in_subgraph(mod(rand_choices_p(k), places_count) + 1);
       connected_transition = node;
       transitions_count++;
       transitions_in_subgraph(transitions_count) = node;
@@ -110,7 +117,7 @@ function [cm, lambda] = spn_generate_random(pn, tn, prob, max_lambda)
 
     % Create a connection between the new node and a node from the subgraph.
     transition_idx = connected_transition - pn;
-    cm(new_place, transition_idx + (rand() > 0.5) * tn) = 1;
+    cm(new_place, transition_idx + rand_dir(k) * tn) = 1;
   endfor
 
   % --- Add more connections based on probability ---


### PR DESCRIPTION
⚡ Bolt: Optimize SPN generation by removing loop overhead

💡 What: Pre-allocated random values `rand_choices_t`, `rand_choices_p`, and `rand_dir` before the inner graph-building loop in `spn_generate_random.m`.
🎯 Why: Calling `randi()` and `rand()` iteratively within Octave loops has significant function call overhead, acting as a massive bottleneck for graph generation.
📊 Impact: Reduced SPN generation time by ~4.25x (~0.84s -> ~0.19s for 100 iterations) according to the benchmark suite, without increasing memory usage.
🔬 Measurement: Verified using `./run_benchmark_suite.sh`.

---
*PR created automatically by Jules for task [5519525545060550862](https://jules.google.com/task/5519525545060550862) started by @CombatOrpheus*