### PR TITLE
⚡ Bolt: Replace O(N) dynamic queue array shifting with O(1) pre-allocated pointers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,6 +26,10 @@
 **Learning:** Constructing arrays by concatenating elements inside `for` loops in Octave is remarkably slow compared to creating matrices using fully vectorized equivalents (`ones()`, vector concatenation).
 **Action:** Replace `for` loop array concatenation with block matrix creation (e.g., `connections = [t_in, t_out]`) wherever feasible for significant performance improvements.
 
+## 2024-05-26 - Dynamic Array Shifting in Queues
+**Learning:** In Octave, dynamic array shifting (e.g., `list(1) = []` or `list = [list, new_item]`) used for implementing queues incurs severe O(N) memory and speed overhead. This becomes a significant bottleneck in graph traversal algorithms like breadth-first search.
+**Action:** Always replace dynamic array shifting with pre-allocated arrays and use `head` and `tail` pointers (e.g., `list(tail) = new_item`, `item = list(head)`) for O(1) queue operations in performance-critical loops.
+
 ## 2024-05-25 - randperm over shuffling entire arrays
 **Learning:** When selecting a small random sample (`k`) from a large population, shuffling the entire population array `population(randperm(length(population)))` is inefficient.
 **Action:** Use `randperm(numel(population), k)` to generate `k` random indices directly, then index into the population.

--- a/get_reachability_graph.m
+++ b/get_reachability_graph.m
@@ -55,7 +55,6 @@ function result_struct = get_reachability_graph(petri_matrix, place_upper_limit=
   C = T_out - T_in;
 
   % --- 2. Initialize data structures for the graph search ---
-  new_markings_list = [1];
   markings_count = 1;
   edge_count = 0;
 
@@ -72,18 +71,25 @@ function result_struct = get_reachability_graph(petri_matrix, place_upper_limit=
   edge_list = zeros(prealloc_size * 5, 2); % Guessing 5 edges per marking on avg.
   arctrans_list = zeros(prealloc_size * 5, 1);
 
+  % Pre-allocate the queue (new_markings_list) to avoid dynamic array shifting
+  % in the main loop, which is an O(N) operation in Octave.
+  new_markings_queue = zeros(1, prealloc_size);
+  new_markings_queue(1) = 1;
+  queue_head = 1;
+  queue_tail = 1;
+
   v_list(:, 1) = M0;
   result_struct.bounded = true;
 
   % --- 3. Explore the state space to build the reachability graph ---
-  while (~isempty(new_markings_list))
+  while (queue_head <= queue_tail)
     if (markings_count > marks_upper_limit)
       result_struct.bounded = false;
       break; % Exit loop, then trim matrices.
     endif
 
-    current_marking_idx = new_markings_list(1);
-    new_markings_list(1) = [];
+    current_marking_idx = new_markings_queue(queue_head);
+    queue_head += 1;
     current_marking = v_list(:, current_marking_idx);
 
     enabled_transitions = find(all(current_marking >= T_in, 1));
@@ -126,7 +132,13 @@ function result_struct = get_reachability_graph(petri_matrix, place_upper_limit=
         next_marking_idx = markings_count;
         v_list(:, next_marking_idx) = next_marking;
         hash_list(next_marking_idx) = next_marking_key;
-        new_markings_list = [new_markings_list, next_marking_idx];
+
+        % Add to queue and resize if necessary
+        queue_tail += 1;
+        if queue_tail > columns(new_markings_queue)
+            new_markings_queue(columns(new_markings_queue) * 2) = 0;
+        endif
+        new_markings_queue(queue_tail) = next_marking_idx;
       endif
 
       edge_count += 1;


### PR DESCRIPTION
💡 **What:** Replaced the dynamically resizing array (`new_markings_list`) used as a queue in `get_reachability_graph.m` with a pre-allocated array (`new_markings_queue`) managed by explicit `head` and `tail` pointers.
🎯 **Why:** In Octave, operations like `list(1) = []` or `list = [list, next_item]` force the engine to reallocate and copy the entire array. For a breadth-first search reachability algorithm processing thousands of states, this $O(N)$ queue operation becomes a massive $O(N^2)$ bottleneck.
📊 **Impact:** Reduces filtering time by avoiding excessive memory allocations and full array shifts on every queue push/pop. Testing confirms identical outputs with noticeably reduced runtime variation on larger graphs, resolving a severe performance anti-pattern.
🔬 **Measurement:** Verification was done via the existing `test_suite.m` which passes successfully, and via `/usr/bin/time` measurements with `run_benchmark_suite.sh` showing reduced wall time during the filtering phase.

---
*PR created automatically by Jules for task [3146499335339567831](https://jules.google.com/task/3146499335339567831) started by @CombatOrpheus*